### PR TITLE
explicit ssl config, and update configmap for boolean values

### DIFF
--- a/helm-chart/binder-launches/Chart.yaml
+++ b/helm-chart/binder-launches/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: binder-launches
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 # kubeVersion: A SemVer range of compatible Kubernetes versions (optional)
 description: A Helm chart for Kubernetes

--- a/helm-chart/binder-launches/templates/configmap.yaml
+++ b/helm-chart/binder-launches/templates/configmap.yaml
@@ -12,12 +12,8 @@ data:
     {{- if .Values.port }}
     port: {{ .Values.port }},
     {{- end }}
-    {{- if .Values.debug }}
     debug: {{ .Values.debug }},
-    {{- end }}
-    {{- if .Values.db.ssl }}
     dbSSL: {{ .Values.db.ssl }},
-    {{- end }}
     //db: "postgres://{{ template "binder-launches.dbURL" . }}"
     db: {{ printf "postgres://%s" (include "binder-launches.dbURL" .) | quote }}
     };

--- a/helm-chart/binder-launches/templates/configmap.yaml
+++ b/helm-chart/binder-launches/templates/configmap.yaml
@@ -4,16 +4,22 @@ metadata:
   name: {{ .Release.Name }}-configmap
 data:
   # `|-` is for declaring a multi-line string
+  # To check boolean values explicity, we use
+  # (kindIs "invalid") to check if the value is nil.
   config.js: |-
     const config = {
     {{- if .Values.baseUrl }}
     baseUrl: {{ .Values.baseUrl | quote }},
     {{- end }}
-    {{- if .Values.port }}
-    port: {{ .Values.port }},
+    {{- if .Values.db.port }}
+    port: {{ .Values.db.port }},
     {{- end }}
+    {{- if not (kindIs "invalid" .Values.debug) }}
     debug: {{ .Values.debug }},
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.db.ssl) }}
     dbSSL: {{ .Values.db.ssl }},
+    {{- end }}
     //db: "postgres://{{ template "binder-launches.dbURL" . }}"
     db: {{ printf "postgres://%s" (include "binder-launches.dbURL" .) | quote }}
     };

--- a/helm-chart/binder-launches/templates/configmap.yaml
+++ b/helm-chart/binder-launches/templates/configmap.yaml
@@ -11,9 +11,6 @@ data:
     {{- if .Values.baseUrl }}
     baseUrl: {{ .Values.baseUrl | quote }},
     {{- end }}
-    {{- if .Values.db.port }}
-    port: {{ .Values.db.port }},
-    {{- end }}
     {{- if not (kindIs "invalid" .Values.debug) }}
     debug: {{ .Values.debug }},
     {{- end }}

--- a/server/server.js
+++ b/server/server.js
@@ -40,19 +40,31 @@ const app = express();
 app.use(expressLogger);
 const port = config.port;
 
-const sequelize = new Sequelize(config.db,
-    {
-        // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html
-        dialect: 'postgres',
-        protocol: 'postgres',
-        dialectOptions: {
-            ssl: {
-                require: config.dbSSL,
-                rejectUnauthorized: false
-            }
-        },
-        logging: config.debug
-    });
+let sequelize;
+if (config.dbSSL){
+    sequelize = new Sequelize(config.db,
+        {
+            // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html
+            dialect: 'postgres',
+            protocol: 'postgres',
+            dialectOptions: {
+                ssl: {
+                    require: true,
+                    rejectUnauthorized: false
+                }
+            },
+            logging: config.debug
+        });
+} else {
+    sequelize = new Sequelize(config.db,
+        {
+            // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html
+            dialect: 'postgres',
+            protocol: 'postgres',
+            logging: config.debug
+        });
+}
+
 
 // init Launch model
 const Launch = _Launch(sequelize, DataTypes);


### PR DESCRIPTION
I am sure there is a better way of treating the Boolean values defined in the YAML config but the current way was failing if `db.ssl` was set to false. (As it will evaluate to `{{- if .Values.db.ssl }}` to `false` and won't set the value). This change assumes `db.ssl` and `debug` are always present.

I'm not sure why but as soon as `dialectOptions.ssl` is included in the sequelize object it tries to launch a ssl connection so changed that. (probably a better way exists).